### PR TITLE
recovering -1 boson pt cases

### DIFF
--- a/Flat/config/GeneralTree.cfg
+++ b/Flat/config/GeneralTree.cfg
@@ -33,6 +33,8 @@ sf_metTrigVBF             float
 sf_metTrigZmmVBF          float
 # misc SFs
 sf_pu                      float
+sf_puUp                    float
+sf_puDown                  float
 sf_npv                     float
 sf_tt                      float
 sf_tt_ext                  float

--- a/Flat/interface/GeneralTree.h
+++ b/Flat/interface/GeneralTree.h
@@ -247,6 +247,8 @@ class GeneralTree : public genericTree {
     float sf_phoTrig = -1;
     float sf_metTrig = -1;
     float sf_pu = -1;
+    float sf_puUp = -1;
+    float sf_puDown = -1;
     float sf_npv = -1;
     float sf_tt = -1;
     float sf_tt_ext = -1;

--- a/Flat/interface/PandaAnalyzer.h
+++ b/Flat/interface/PandaAnalyzer.h
@@ -99,6 +99,8 @@ private:
     enum CorrectionType { //!< enum listing relevant corrections applied to MC
         cNPV=0,       //!< npv weight
         cPU,          //!< true pu weight
+        cPUUp,        //!< true pu weight
+        cPUDown,      //!< true pu weight
         cEleVeto,     //!< monojet SF, Veto ID for e
         cEleTight,    //!< monojet SF, Tight ID for e
         cEleReco,     //!< monojet SF, tracking for e

--- a/Flat/src/PandaAnalyzer.cc
+++ b/Flat/src/PandaAnalyzer.cc
@@ -248,6 +248,8 @@ void PandaAnalyzer::SetDataDir(const char *s) {
   // pileup
   OpenCorrection(cNPV,dirPath+"moriond17/normalized_npv.root","data_npv_Wmn",1);
   OpenCorrection(cPU,dirPath+"moriond17/puWeights_80x_37ifb.root","puWeights",1);
+  OpenCorrection(cPUUp,dirPath+"moriond17/puWeights_80x_37ifb.root","puWeightsUp",1);
+  OpenCorrection(cPUDown,dirPath+"moriond17/puWeights_80x_37ifb.root","puWeightsDown",1);
 
   // electrons
   OpenCorrection(cEleVeto,dirPath+"moriond17/scaleFactor_electron_summer16.root",
@@ -865,6 +867,8 @@ void PandaAnalyzer::Run() {
     } else {
       gt->sf_npv = GetCorr(cNPV,gt->npv);
       gt->sf_pu = GetCorr(cPU,gt->pu);
+      gt->sf_puUp = GetCorr(cPUUp,gt->pu);
+      gt->sf_puDown = GetCorr(cPUDown,gt->pu);
     }
 
     if (uncReader==0) {


### PR DESCRIPTION
perhaps not the most elegant since it duplicates the filling of the kfactors

on the other hand couple of observations:
   * on 50K events, the genMET = sum of all neutrinos as expected (== Zpt at the moment)
   * no gen boson -1 cases on any of the W MC.. but why not? we should on average have the same amount. could this be the difference we see in the W template comparisons?
