### PR TITLE
JES variations and met significance

### DIFF
--- a/Flat/config/GeneralTree.cfg
+++ b/Flat/config/GeneralTree.cfg
@@ -149,6 +149,14 @@ jet2GenPt                 float
 jet2Eta                   float
 jet2CSV                   float
 jet2CMVA                  float
+jet1PtUp                  float
+jet1PtDown                float
+jet1EtaUp                 float
+jet1EtaDown               float
+jet2PtUp                  float
+jet2PtDown                float
+jet2EtaUp                 float
+jet2EtaDown               float
 barrelJet1Pt              float
 barrelJet1Eta             float
 barrelHT                  float

--- a/Flat/interface/GeneralTree.h
+++ b/Flat/interface/GeneralTree.h
@@ -501,6 +501,14 @@ class GeneralTree : public genericTree {
     float jet2Eta = -1;
     float jet2CSV = -1;
     float jet2CMVA = -1;
+    float jet2EtaUp = -1;
+    float jet2EtaDown = -1;
+    float jet1EtaUp = -1;
+    float jet1EtaDown = -1;
+    float jet1PtUp = -1;
+    float jet1PtDown = -1;
+    float jet2PtUp = -1;
+    float jet2PtDown = -1;
     float isojet1Pt = -1;
     float isojet1CSV = -1;
     int isojet1Flav = -1;

--- a/Flat/interface/PandaAnalyzer.h
+++ b/Flat/interface/PandaAnalyzer.h
@@ -339,11 +339,15 @@ private:
     panda::Jet *jot1 = 0, *jot2 = 0;
     panda::Jet *jotUp1 = 0, *jotUp2 = 0;
     panda::Jet *jotDown1 = 0, *jotDown2 = 0;
+    panda::Jet *jetUp1 = 0, *jetUp2 = 0;
+    panda::Jet *jetDown1 = 0, *jetDown2 = 0;
     std::vector<panda::GenJet> genJetsNu;
     float genBosonPtMin, genBosonPtMax;
     int looseLep1PdgId, looseLep2PdgId;
     std::vector<TString> wIDs;
     float *bjetreg_vars = 0;
+
+    float jetPtThreshold=30;
     
 };
 

--- a/Flat/src/GeneralTree.cc
+++ b/Flat/src/GeneralTree.cc
@@ -389,6 +389,14 @@ void GeneralTree::Reset() {
     jet2Eta = -1;
     jet2CSV = -1;
     jet2CMVA = -1;
+    jet2EtaUp = -1;
+    jet2EtaDown = -1;
+    jet1EtaUp = -1;
+    jet1EtaDown = -1;
+    jet1PtUp = -1;
+    jet1PtDown = -1;
+    jet2PtUp = -1;
+    jet2PtDown = -1;
     isojet1Pt = -1;
     isojet1CSV = -1;
     isojet1Flav = 0;
@@ -529,6 +537,14 @@ void GeneralTree::WriteTree(TTree *t) {
     Book("hbbpt_reg",&hbbpt_reg,"hbbpt_reg/F");
     Book("hbbjtidx",hbbjtidx,"hbbjtidx[2]/I");
     Book("jetRegFac",jetRegFac,"jetRegFac[2]/F");
+    Book("jet1EtaUp",&jet1EtaUp,"jet1EtaUp/F");
+    Book("jet1EtaDown",&jet1EtaDown,"jet1EtaDown/F");
+    Book("jet1PtUp",&jet1PtUp,"jet1PtUp/F");
+    Book("jet1PtDown",&jet1PtDown,"jet1PtDown/F");
+    Book("jet2EtaUp",&jet2EtaUp,"jet2EtaUp/F");
+    Book("jet2EtaDown",&jet2EtaDown,"jet2EtaDown/F");
+    Book("jet2PtUp",&jet2PtUp,"jet2PtUp/F");
+    Book("jet2PtDown",&jet2PtDown,"jet2PtDown/F");
   }
 
   if (vbf) { 
@@ -557,6 +573,8 @@ void GeneralTree::WriteTree(TTree *t) {
     Book("jot1EtaDown",&jot1EtaDown,"jot1EtaDown/F");
     Book("jot1PtUp",&jot1PtUp,"jot1PtUp/F");
     Book("jot1PtDown",&jot1PtDown,"jot1PtDown/F");
+    Book("jot2EtaUp",&jot2EtaUp,"jot2EtaUp/F");
+    Book("jot2EtaDown",&jot2EtaDown,"jot2EtaDown/F");
     Book("jot2PtUp",&jot2PtUp,"jot2PtUp/F");
     Book("jot2PtDown",&jot2PtDown,"jot2PtDown/F");
     Book("jot12MassUp",&jot12MassUp,"jot12MassUp/F");
@@ -565,8 +583,6 @@ void GeneralTree::WriteTree(TTree *t) {
     Book("jot12MassDown",&jot12MassDown,"jot12MassDown/F");
     Book("jot12DEtaDown",&jot12DEtaDown,"jot12DEtaDown/F");
     Book("jot12DPhiDown",&jot12DPhiDown,"jot12DPhiDown/F");
-    Book("jot2EtaUp",&jot2EtaUp,"jot2EtaUp/F");
-    Book("jot2EtaDown",&jot2EtaDown,"jot2EtaDown/F");
     Book("jot1VBFID",&jot1VBFID,"jot1VBFID/I");
     Book("sf_qcdV_VBF2lTight",&sf_qcdV_VBF2lTight,"sf_qcdV_VBF2lTight/F");
     Book("sf_qcdV_VBF2l",&sf_qcdV_VBF2l,"sf_qcdV_VBF2l/F");

--- a/Flat/src/ModulesJets.cc
+++ b/Flat/src/ModulesJets.cc
@@ -42,6 +42,8 @@ void PandaAnalyzer::JetBasics()
   jot1=0; jot2=0;
   jotUp1=0; jotUp2=0;
   jotDown1=0; jotDown2=0;
+  jetUp1=0; jetUp2=0;
+  jetDown1=0; jetDown2=0;
   gt->dphipuppimet=999; gt->dphipfmet=999;
   gt->dphipuppiUW=999; gt->dphipfUW=999;
   gt->dphipuppiUZ=999; gt->dphipfUZ=999;
@@ -69,7 +71,7 @@ void PandaAnalyzer::JetBasics()
       ++(gt->jetNMBtags);
     }
 
-    if ((analysis->hbb && jet.pt()>20) || jet.pt()>30) { // nominal jets
+    if (jet.pt()>jetPtThreshold) { // nominal jets
       cleanedJets.push_back(&jet);
       if (cleanedJets.size()<3) {
         bool isBad = GetCorr(cBadECALJets,jet.eta(),jet.phi()) > 0;
@@ -276,8 +278,9 @@ void PandaAnalyzer::IsoJet(panda::Jet& jet)
 
 void PandaAnalyzer::JetVaryJES(panda::Jet& jet)
 {
-  // do jes variation OUTSIDE of pt>30 check
-  if (jet.ptCorrUp>30) {
+  // do jes variation OUTSIDE of nominal jet check 
+  if (jet.ptCorrUp>jetPtThreshold) { // Vary the pT up
+    // forward and central jets:
     if (jet.ptCorrUp > gt->jot1PtUp) {
       if (jotUp1) {
         jotUp2 = jotUp1;
@@ -292,8 +295,26 @@ void PandaAnalyzer::JetVaryJES(panda::Jet& jet)
       gt->jot2PtUp = jet.ptCorrUp;
       gt->jot2EtaUp = jet.eta();
     }
+    // central only jets:
+    if (fabs(jet.eta()) < 2.4) {
+      if (jet.ptCorrUp > gt->jet1PtUp) {
+        if (jetUp1) {
+          jetUp2 = jetUp1;
+          gt->jet2PtUp = gt->jet1PtUp;
+          gt->jet2EtaUp = gt->jet1EtaUp;
+        }
+        jetUp1 = &jet;
+        gt->jet1PtUp = jet.ptCorrUp;
+        gt->jet1EtaUp = jet.eta();
+      } else if (jet.ptCorrUp > gt->jet2PtUp) {
+        jetUp2 = &jet;
+        gt->jet2PtUp = jet.ptCorrUp;
+        gt->jet2EtaUp = jet.eta();
+      }
+    }
   }
-  if (jet.ptCorrDown>30) {
+  if (jet.ptCorrDown>jetPtThreshold) { // Vary the pT down:
+    // forward and central jets:
     if (jet.ptCorrDown > gt->jot1PtDown) {
       if (jotDown1) {
         jotDown2 = jotDown1;
@@ -307,6 +328,23 @@ void PandaAnalyzer::JetVaryJES(panda::Jet& jet)
       jotDown2 = &jet;
       gt->jot2PtDown = jet.ptCorrDown;
       gt->jot2EtaDown = jet.eta();
+    }
+    // central only jets:
+    if (fabs(jet.eta()) < 2.4) {
+      if (jet.ptCorrDown > gt->jet1PtDown) {
+        if (jetDown1) {
+          jetDown2 = jetDown1;
+          gt->jet2PtDown = gt->jet1PtDown;
+          gt->jet2EtaDown = gt->jet1EtaDown;
+        }
+        jetDown1 = &jet;
+        gt->jet1PtDown = jet.ptCorrDown;
+        gt->jet1EtaDown = jet.eta();
+      } else if (jet.ptCorrDown > gt->jet2PtDown) {
+        jetDown2 = &jet;
+        gt->jet2PtDown = jet.ptCorrDown;
+        gt->jet2EtaDown = jet.eta();
+      }
     }
   }
   tr->TriggerSubEvent("vary jet JES");

--- a/Flat/src/PandaAnalyzer.cc
+++ b/Flat/src/PandaAnalyzer.cc
@@ -193,6 +193,8 @@ int PandaAnalyzer::Init(TTree *t, TH1D *hweights, TTree *weightNames)
     jetDefGen = new fastjet::JetDefinition(fastjet::antikt_algorithm,radius);
   }
 
+  // Custom jet pt threshold
+  if (analysis->hbb) jetPtThreshold=20;
 
   if (DEBUG) PDebug("PandaAnalyzer::Init","Finished configuration");
 
@@ -356,7 +358,7 @@ void PandaAnalyzer::SetDataDir(const char *s)
                  "hden_monojet_recoil_clone_passed",1);
   OpenCorrection(cTrigEle,dirPath+"moriond17/eleTrig.root","hEffEtaPt",2);
   OpenCorrection(cTrigMu,dirPath+"trigger_eff/muon_trig_Run2016BtoF.root",
-		 "IsoMu24_OR_IsoTkMu24_PtEtaBins/efficienciesDATA/abseta_pt_DATA",2);
+                 "IsoMu24_OR_IsoTkMu24_PtEtaBins/efficienciesDATA/abseta_pt_DATA",2);
   OpenCorrection(cTrigPho,dirPath+"moriond17/photonTriggerEfficiency_photon_TH1F.root",
                  "hden_photonpt_clone_passed",1);
   OpenCorrection(cTrigMETZmm,dirPath+"moriond17/metTriggerEfficiency_zmm_recoil_monojet_TH1F.root",
@@ -664,15 +666,18 @@ bool PandaAnalyzer::PassPreselection()
   }
 
   if (preselBits & kVHBB) {
+    double theBestMet = TMath::Max(TMath::Max(gt->pfmetUp, gt->pfmetDown), gt->pfmet);
+    double theBestLeadingJet = TMath::Max(TMath::Max(gt->jet1PtUp, gt->jet1PtDown), gt->jet1Pt);
+    double theBestSubLeadingJet = TMath::Max(TMath::Max(gt->jet2PtUp, gt->jet2PtDown), gt->jet2Pt);
     // ZnnHbb
     if (
-      gt->pfmet>150 && 
-      gt->nJet>=2 && gt->jetPt[0]>50 && gt->jetPt[1]>50 &&
+      theBestMet>150 && 
+      theBestLeadingJet>50 && theBestSubLeadingJet>25 &&
       (gt->hbbpt>50 || (gt->nFatjet>0 && gt->fj1Pt>200))
     ) isGood=true;
     // WlnHbb
     else if (
-      gt->nJet>=2 && gt->jetPt[0]>25 && gt->jetPt[1]>25 &&
+      theBestLeadingJet>25 && theBestSubLeadingJet>25 &&
       (
        (gt->nTightElectron >0 && gt->electronPt[0]>25) ||
        (gt->nTightMuon > 0 && gt->muonPt[0]>25)
@@ -681,7 +686,7 @@ bool PandaAnalyzer::PassPreselection()
     ) isGood=true;
     // ZllHbb
     else if (
-      gt->nJet>=2 && gt->jetPt[0]>25 && gt->jetPt[1]>25 &&
+      theBestLeadingJet>25 && theBestSubLeadingJet>25 &&
       (
        (
         gt->nTightElectron>0 && 
@@ -821,27 +826,27 @@ void PandaAnalyzer::Run()
     triggerHandlers[kSingleEleTrig].addTriggers(paths);
     
     paths = {
-	      "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL",
-	      "HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL",
-	      "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ",
-	      "HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ"
+          "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL",
+          "HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL",
+          "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_DZ",
+          "HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_DZ"
     };
     triggerHandlers[kDoubleMuTrig].addTriggers(paths);
     paths = {
-	      "HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ",
-	      "HLT_DoubleEle24_22_eta2p1_WPLoose_Gsf"
+          "HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_DZ",
+          "HLT_DoubleEle24_22_eta2p1_WPLoose_Gsf"
     };
     triggerHandlers[kDoubleEleTrig].addTriggers(paths);
     
     paths = {
-	      "HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ",
-	      "HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL",
-	      "HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ",
-	      "HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL",
-	      "HLT_Mu23_TrkIsoVVL_Ele8_CaloIdL_TrackIdL_IsoVL_DZ",
-	      "HLT_Mu23_TrkIsoVVL_Ele8_CaloIdL_TrackIdL_IsoVL",
-	      "HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ",
-	      "HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL"
+          "HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ",
+          "HLT_Mu12_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL",
+          "HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_DZ",
+          "HLT_Mu23_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL",
+          "HLT_Mu23_TrkIsoVVL_Ele8_CaloIdL_TrackIdL_IsoVL_DZ",
+          "HLT_Mu23_TrkIsoVVL_Ele8_CaloIdL_TrackIdL_IsoVL",
+          "HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL_DZ",
+          "HLT_Mu8_TrkIsoVVL_Ele23_CaloIdL_TrackIdL_IsoVL"
     };
     triggerHandlers[kEMuTrig].addTriggers(paths);
 
@@ -1047,9 +1052,9 @@ void PandaAnalyzer::Run()
       SignalInfo();
 
       if (analysis->complicatedLeptons) 
-	GenStudyEWK();
+        GenStudyEWK();
       else
-	LeptonSFs();
+        LeptonSFs();
 
       PhotonSFs();
 

--- a/Flat/src/PandaAnalyzer.cc
+++ b/Flat/src/PandaAnalyzer.cc
@@ -993,8 +993,6 @@ void PandaAnalyzer::Run()
 
     tr->TriggerEvent("met");
 
-    GetMETSignificance();
-
     // electrons and muons
     if (analysis->complicatedLeptons) {
       ComplicatedLeptons();
@@ -1029,6 +1027,9 @@ void PandaAnalyzer::Run()
 
     if (!analysis->genOnly && !PassPreselection()) // only check reco presel here
       continue;
+
+    if (analysis->monoh)
+      GetMETSignificance();
 
     if (!isData) {
       if (analysis->fatjet)

--- a/data/jec/23Sep2016V4/Summer16_23Sep2016V4_MC_UncertaintySources_AK4PFPuppi.txt
+++ b/data/jec/23Sep2016V4/Summer16_23Sep2016V4_MC_UncertaintySources_AK4PFPuppi.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:22ac75732cee9a42cf88a630673096474580ab6f618af36ff0644fd6b674bad6
+size 2228172

--- a/data/jec/23Sep2016V4/Summer16_23Sep2016V4_MC_UncertaintySources_AK4PFchs.txt
+++ b/data/jec/23Sep2016V4/Summer16_23Sep2016V4_MC_UncertaintySources_AK4PFchs.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:22ac75732cee9a42cf88a630673096474580ab6f618af36ff0644fd6b674bad6
+size 2228172

--- a/data/jec/23Sep2016V4/Summer16_23Sep2016V4_MC_UncertaintySources_AK8PFPuppi.txt
+++ b/data/jec/23Sep2016V4/Summer16_23Sep2016V4_MC_UncertaintySources_AK8PFPuppi.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:22ac75732cee9a42cf88a630673096474580ab6f618af36ff0644fd6b674bad6
+size 2228172

--- a/data/jec/23Sep2016V4/Summer16_23Sep2016V4_MC_UncertaintySources_AK8PFchs.txt
+++ b/data/jec/23Sep2016V4/Summer16_23Sep2016V4_MC_UncertaintySources_AK8PFchs.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:22ac75732cee9a42cf88a630673096474580ab6f618af36ff0644fd6b674bad6
+size 2228172


### PR DESCRIPTION
Calculate the first 2 leading central jets with the full JES varied up and down.
For VH, save the event if the loosest among all of the 1 sigma variations pass the preselection.
Only compute the MET significance for a certain flag, and only after the reco preselection.
